### PR TITLE
Install jaxlib with poetry, cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@ A (soon-to-be) collection of tools for generating [dalle-mini](https://github.co
 Install the dependencies, then try out the CLI. Try `python generate.py --help` for more.
 
 ```sh
-# Install poetry
-curl -sSL https://install.python-poetry.org | python3 -
+# If you installed poetry 1.x before, uninstall first
+curl -sSL https://install.python-poetry.org | python3 - --uninstall
+
+# Install poetry 1.2.x
+curl -sSL https://install.python-poetry.org | python3 - --preview
 
 # Create virtual env for this project, install requirements
 poetry install

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ A (soon-to-be) collection of tools for generating [dalle-mini](https://github.co
 Install the dependencies, then try out the CLI. Try `python generate.py --help` for more.
 
 ```sh
-# If you installed poetry 1.x before, uninstall first
+# If you installed poetry 1.1.x before, uninstall first
 curl -sSL https://install.python-poetry.org | python3 - --uninstall
 
-# Install poetry 1.2.x
+# Install poetry 1.2.x preview
 curl -sSL https://install.python-poetry.org | python3 - --preview
 
 # Create virtual env for this project, install requirements

--- a/poetry.lock
+++ b/poetry.lock
@@ -68,9 +68,9 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope-interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope-interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope-interface", "cloudpickle"]
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
@@ -130,7 +130,6 @@ six = ">=1.9.0"
 webencodings = "*"
 
 [package.extras]
-css = ["tinycss2 (>=1.1.0)"]
 dev = ["pip-tools (==6.5.1)", "pytest (==7.1.1)", "flake8 (==4.0.1)", "tox (==3.24.5)", "sphinx (==4.3.2)", "twine (==4.0.0)", "wheel (==0.37.1)", "hashin (==0.17.0)", "black (==22.3.0)", "mypy (==0.942)"]
 
 [[package]]
@@ -543,6 +542,7 @@ python-versions = ">=2.7"
 [package.dependencies]
 decorator = {version = "*", markers = "python_version > \"3.6\""}
 ipython = {version = ">=7.17.0", markers = "python_version > \"3.6\""}
+setuptools = "*"
 toml = {version = ">=0.10.2", markers = "python_version > \"3.6\""}
 
 [[package]]
@@ -588,6 +588,7 @@ pexpect = {version = ">4.3", markers = "sys_platform != \"win32\""}
 pickleshare = "*"
 prompt-toolkit = ">=2.0.0,<3.0.0 || >3.0.0,<3.0.1 || >3.0.1,<3.1.0"
 pygments = ">=2.4.0"
+setuptools = ">=18.5"
 stack-data = "*"
 traitlets = ">=5"
 
@@ -691,6 +692,26 @@ flatbuffers = ">=1.12,<3.0"
 numpy = ">=1.19"
 scipy = "*"
 
+[package.source]
+type = "url"
+url = "https://storage.googleapis.com/jax-releases/mac/jaxlib-0.3.10-cp310-none-macosx_11_0_arm64.whl"
+[[package]]
+name = "jaxlib"
+version = "0.3.10+cuda11.cudnn82"
+description = "XLA library for JAX"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+absl-py = "*"
+flatbuffers = ">=1.12,<3.0"
+numpy = ">=1.19"
+scipy = "*"
+
+[package.source]
+type = "url"
+url = "https://storage.googleapis.com/jax-releases/cuda11/jaxlib-0.3.10+cuda11.cudnn82-cp310-none-manylinux2014_x86_64.whl"
 [[package]]
 name = "jedi"
 version = "0.18.1"
@@ -1454,6 +1475,19 @@ python-versions = ">=3.6"
 test = ["pytest"]
 
 [[package]]
+name = "setuptools"
+version = "62.6.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-reredirects", "sphinxcontrib-towncrier", "furo"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-enabler (>=1.0.1)", "pytest-perf", "mock", "flake8-2020", "virtualenv (>=13.0.0)", "wheel", "pip (>=19.1)", "jaraco.envs (>=2.2)", "pytest-xdist", "jaraco.path (>=3.2.0)", "build", "filelock (>=3.4.0)", "pip-run (>=8.8)", "ini2toml[lite] (>=0.9)", "tomli-w (>=1.0.0)", "pytest-black (>=0.3.7)", "pytest-cov", "pytest-mypy (>=0.9.1)"]
+testing-integration = ["pytest", "pytest-xdist", "pytest-enabler", "virtualenv (>=13.0.0)", "tomli", "wheel", "jaraco.path (>=3.2.0)", "jaraco.envs (>=2.2)", "build", "filelock (>=3.4.0)"]
+
+[[package]]
 name = "setuptools-scm"
 version = "7.0.2"
 description = "the blessed package to manage your versions by scm tags"
@@ -1463,6 +1497,7 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 packaging = ">=20.0"
+setuptools = "*"
 tomli = ">=1.0.0"
 typing-extensions = "*"
 
@@ -1796,6 +1831,7 @@ PyYAML = "*"
 requests = ">=2.0.0,<3"
 sentry-sdk = ">=1.0.0"
 setproctitle = "*"
+setuptools = "*"
 shortuuid = ">=0.5.0"
 six = ">=1.13.0"
 
@@ -1849,8 +1885,8 @@ notebook = ">=4.4.1"
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.10.4,<3.11"
-content-hash = "14a37bc967e5e231cbe38468bb05a8875ac35b01df2f6bf16802cc486df4fd98"
+python-versions = ">=3.10,<3.11"
+content-hash = "ddbcd698e20122c87dd355a103cc6d1e653dc30491234851283fc74323e1944c"
 
 [metadata.files]
 absl-py = [
@@ -2177,19 +2213,7 @@ itsdangerous = [
 jax = [
     {file = "jax-0.3.13.tar.gz", hash = "sha256:4ab4865b7007a36e2894a4aff8baf3ffeb6e51e435403c59ba9bc3f741ca3504"},
 ]
-jaxlib = [
-    {file = "jaxlib-0.3.10-cp310-none-macosx_10_9_x86_64.whl", hash = "sha256:7b6219b5cd22580ffcc723c789c248f3f62d4a395289308b99a3a9dbc0687bae"},
-    {file = "jaxlib-0.3.10-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:cd780a9509461103df8c71473f4e2333853e0f6884ad5a6362757bd42f8a481b"},
-    {file = "jaxlib-0.3.10-cp310-none-manylinux2014_x86_64.whl", hash = "sha256:18e2464f7fc19d4996b095f8c981b36e4b5f06558c63b63a9f792208ceb93fee"},
-    {file = "jaxlib-0.3.10-cp37-none-macosx_10_9_x86_64.whl", hash = "sha256:f5eebd7be2e679a20af0b47596b46cf9cda696684cb70f233dde1c830b9f4f24"},
-    {file = "jaxlib-0.3.10-cp37-none-manylinux2014_x86_64.whl", hash = "sha256:153e99306f134f4efc906a9d223aeaf3777b7c46bbe4ba08243b4f63a7cf592f"},
-    {file = "jaxlib-0.3.10-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:3dec003496634685581e7039f0bfa2144efac8aa7626668b46e9d8772e5c19f2"},
-    {file = "jaxlib-0.3.10-cp38-none-macosx_11_0_arm64.whl", hash = "sha256:a506cd07565683185e985d2f2d71987a3b82cbe75738d78f3118878b2362e429"},
-    {file = "jaxlib-0.3.10-cp38-none-manylinux2014_x86_64.whl", hash = "sha256:18e005b96bf18c46bc43b46ca1681aa5a6037ef1c027359a7336eeca4a237bb4"},
-    {file = "jaxlib-0.3.10-cp39-none-macosx_10_9_x86_64.whl", hash = "sha256:3875edc0ff7d555e9a60adb88fe7fa724d8a997a4d9610badcaa5ebfd4ebbf00"},
-    {file = "jaxlib-0.3.10-cp39-none-macosx_11_0_arm64.whl", hash = "sha256:cd30a9af14fdbf675e6672bb1af77be0ce3040b86fed573c5656b8fb4150d550"},
-    {file = "jaxlib-0.3.10-cp39-none-manylinux2014_x86_64.whl", hash = "sha256:e67d2f82f543050b682d85bf33a271a6ad365b7f96d98cc86347a2fd636b55ae"},
-]
+jaxlib = []
 jedi = [
     {file = "jedi-0.18.1-py2.py3-none-any.whl", hash = "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d"},
     {file = "jedi-0.18.1.tar.gz", hash = "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"},
@@ -3011,6 +3035,10 @@ setproctitle = [
     {file = "setproctitle-1.2.3-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06aab65e68163ead9d046b452dd9ad1fc6834ce6bde490f63fdce3be53e9cc73"},
     {file = "setproctitle-1.2.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:97accd117392b1e57e09888792750c403d7729b7e4b193005178b3736b325ea0"},
     {file = "setproctitle-1.2.3.tar.gz", hash = "sha256:ecf28b1c07a799d76f4326e508157b71aeda07b84b90368ea451c0710dbd32c0"},
+]
+setuptools = [
+    {file = "setuptools-62.6.0-py3-none-any.whl", hash = "sha256:c1848f654aea2e3526d17fc3ce6aeaa5e7e24e66e645b5be2171f3f6b4e5a178"},
+    {file = "setuptools-62.6.0.tar.gz", hash = "sha256:990a4f7861b31532871ab72331e755b5f14efbe52d336ea7f6118144dd478741"},
 ]
 setuptools-scm = [
     {file = "setuptools_scm-7.0.2-py3-none-any.whl", hash = "sha256:ec120c99027a785c7a349667480a5b2100dfc7d5063e545c93f3735508945aef"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["poetry>=1.1"]
+requires = ["poetry-core"]
 build-backend = "poetry.masonry.api"
 
 [tool.poetry]
@@ -14,15 +14,17 @@ fire = "^0.4.0"
 Flask = "^2.1.2"
 ipywidgets = "^7.7.1"
 pySqsListener = "^0.8.10"
-python = ">=3.10.4,<3.11"
+python = ">=3.10,<3.11"
 python-slugify = "^6.1.2"
 tokenizers = "~=0.11.6"
 vqgan-jax = {git = "https://github.com/patil-suraj/vqgan-jax.git", rev = "main"}
 slack-sdk = "^3.17.2"
 slack-bolt = "^1.14.0"
 tqdm = "^4.64.0"
-jax = "^0.3.13"
-jaxlib = "^0.3.10"
+jaxlib = [
+     {url = "https://storage.googleapis.com/jax-releases/cuda11/jaxlib-0.3.10+cuda11.cudnn82-cp310-none-manylinux2014_x86_64.whl", markers = "platform_machine == 'linux'"},
+     {url = "https://storage.googleapis.com/jax-releases/mac/jaxlib-0.3.10-cp310-none-macosx_11_0_arm64.whl", markers="platform_machine == 'arm64'"}
+ ]
 
 [tool.poetry.dev-dependencies]
 black = "~22.3.0"

--- a/server.py
+++ b/server.py
@@ -49,7 +49,11 @@ def output(path):
             return redirect(f"/output/{path}")
 
         return render_template(
-            "template.html", prompt=prompt, imgs=imgs, expected_img_count=expectedimgs, show_links=True
+            "template.html",
+            prompt=prompt,
+            imgs=imgs,
+            expected_img_count=expectedimgs,
+            show_links=True,
         )
 
     else:

--- a/sitegen.py
+++ b/sitegen.py
@@ -42,8 +42,11 @@ def get_dir_details(path):
     with open(f"{path}/prompt.txt", "r") as rp:
         prompt = rp.read()
 
-    imgs = [ os.path.basename(x) for x in glob.glob(f"{path}/[!f]*.png") ] #a small hack to ignore "final.png"
-    return ( prompt, imgs )
+    imgs = [
+        os.path.basename(x) for x in glob.glob(f"{path}/[!f]*.png")
+    ]  # a small hack to ignore "final.png"
+    return (prompt, imgs)
+
 
 def generate_index(path, show_links=False):
     tl = jinja2.FileSystemLoader(searchpath="./templates")
@@ -53,7 +56,9 @@ def generate_index(path, show_links=False):
     if imgs is None or len(imgs) == 0:
         return None
 
-    return template.render(prompt=prompt, imgs=imgs, expected_img_count=len(imgs), show_links=show_links)
+    return template.render(
+        prompt=prompt, imgs=imgs, expected_img_count=len(imgs), show_links=show_links
+    )
 
 
 if __name__ == "__main__":

--- a/slackbot.py
+++ b/slackbot.py
@@ -18,7 +18,7 @@ app = App(token=SLACK_BOT_TOKEN)
 
 
 @app.event("app_mention")
-def mention_handler(body, say, logger):
+def mention_handler_app_mention(body, say, logger):
     event = body["event"]
     thread_ts = event.get("thread_ts", None) or event["ts"]
     prompt = (
@@ -54,7 +54,7 @@ def mention_handler(body, say, logger):
 
 
 @app.event("message")
-def mention_handler(body, say):
+def mention_handler_message(body, say):
     event = body["event"]
     thread_ts = event.get("thread_ts", None) or event["ts"]
     if "text" not in event:

--- a/slackbot.py
+++ b/slackbot.py
@@ -1,58 +1,76 @@
 #!/usr/bin/env python
 
 import os
-import time
-from tqdm import tqdm
-from request import send as send_queue_request
+
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
+from tqdm import tqdm
 
-SLACK_BOT_TOKEN = os.environ['SLACK_BOT_TOKEN']
-SLACK_APP_TOKEN = os.environ['SLACK_APP_TOKEN']
+from request import send as send_queue_request
+
+# import time
+
+
+SLACK_BOT_TOKEN = os.environ["SLACK_BOT_TOKEN"]
+SLACK_APP_TOKEN = os.environ["SLACK_APP_TOKEN"]
 
 app = App(token=SLACK_BOT_TOKEN)
 
+
 @app.event("app_mention")
 def mention_handler(body, say, logger):
-	event = body["event"]
-	thread_ts = event.get("thread_ts", None) or event["ts"]
-	prompt = event["text"].replace(event["text"].split(' ')[0].strip(), "").strip() # i feel dirty but its late
-	print(f"Generating {prompt=}")
-	# start = time.time()
-	rundir = send_queue_request(prompt)
-	say(text=f'On it!', thread_ts=thread_ts)
+    event = body["event"]
+    thread_ts = event.get("thread_ts", None) or event["ts"]
+    prompt = (
+        event["text"].replace(event["text"].split(" ")[0].strip(), "").strip()
+    )  # i feel dirty but its late
+    print(f"Generating {prompt=}")
+    # start = time.time()
+    rundir = send_queue_request(prompt)
+    say(text="On it!", thread_ts=thread_ts)
 
-	max_t = 8000000 # my 2080Ti can generate from SQS to final image in: 1672800 ticks
-	for i in tqdm(range(max_t)):
-		if i % 100000 == 0:
-			print(f"Checking {rundir} {i}/{max_t}")
-		
-		if os.path.exists(f'output/{rundir}/final.png'):
-			img = f'https://dalle-mini-tools.xeb.ai/output/{rundir}/final.png'
-			print(f"Found {img}")
-			say(img)
-			# say(img, thread_ts=thread_ts)
-			# end = time.time()
-			# duration = (start - end)
-			# # if duration >= 86400:
-			# # 	days = int(duration / 86400)
-			# elapsed = time.strftime("%H hours, %M minutes, %S seconds", time.gmtime(duration))
-			# say(f'Took me {elapsed}.', thread_ts=thread_ts)
-			return
+    max_t = 8000000  # my 2080Ti can generate from SQS to final image in: 1672800 ticks
+    for i in tqdm(range(max_t)):
+        if i % 100000 == 0:
+            print(f"Checking {rundir} {i}/{max_t}")
 
-	say(text=f'...I gave up.', thread_ts=thread_ts)
+        if os.path.exists(f"output/{rundir}/final.png"):
+            img = f"https://dalle-mini-tools.xeb.ai/output/{rundir}/final.png"
+            print(f"Found {img}")
+            say(img)
+
+            # say(img, thread_ts=thread_ts)
+            # end = time.time()
+            # duration = start - end
+            # # if duration >= 86400:
+            # # 	days = int(duration / 86400)
+            # elapsed = time.strftime(
+            #     "%H hours, %M minutes, %S seconds", time.gmtime(duration)
+            # )
+            # say(f"Took me {elapsed}.", thread_ts=thread_ts)
+            return
+
+    say(text="...I gave up.", thread_ts=thread_ts)
+
 
 @app.event("message")
 def mention_handler(body, say):
-	event = body["event"]
-	thread_ts = event.get("thread_ts", None) or event["ts"]
-	if "text" not in event:
-		return
+    event = body["event"]
+    thread_ts = event.get("thread_ts", None) or event["ts"]
+    if "text" not in event:
+        return
 
-	message = event["text"].strip()
-	if "generation station" in message.lower():
-		say(text='What was that? Did you want to generate an image? Just mention me (@ImageGen) and tell me what you want.', thread_ts=thread_ts)
+    message = event["text"].strip()
+    if "generation station" in message.lower():
+        say(
+            text=(
+                "What was that? Did you want to generate an image? Just mention me"
+                " (@ImageGen) and tell me what you want."
+            ),
+            thread_ts=thread_ts,
+        )
+
 
 if __name__ == "__main__":
-	handler = SocketModeHandler(app, SLACK_APP_TOKEN)
-	handler.start()
+    handler = SocketModeHandler(app, SLACK_APP_TOKEN)
+    handler.start()

--- a/worker.py
+++ b/worker.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 import os
-import fire
 import subprocess
-from generate import Generator
+
+import fire
 from sqs_listener import SqsListener
 
 from generate import Generator
@@ -13,20 +13,19 @@ class ImgGenListener(SqsListener):
     def init_model(self, output_dir, clip_scores, postprocess):
         self.generator = Generator(output_dir, clip_scores)
         self.postprocess = postprocess
-        print(f"Initialized model")
+        print("Initialized model")
 
     def postprocessing(self, run_name):
         if not self.postprocess:
-            print(f"Postprocessing not enabled, skipping...")
+            print("Postprocessing not enabled, skipping...")
 
         if os.path.exists("postprocess.sh"):
-            cmds = [ "./postprocess.sh", run_name ]
+            cmds = ["./postprocess.sh", run_name]
             p = subprocess.Popen(cmds, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             out, err = p.communicate()
             if p.returncode != 0:
-                print("-"**5)
+                print("-" ** 5)
                 print(f"Exception\n{err=}\n\n{out=}")
-            
 
     def handle_message(self, body, attr, msg_attr):
         print(f"Processing {body=} {attr=} {msg_attr=}")
@@ -36,12 +35,13 @@ class ImgGenListener(SqsListener):
         self.postprocessing(run_name)
         print(f"Processed! {body=}")
 
+
 def main(
-    output_dir="output", 
-    clip_scores=False, 
+    output_dir="output",
+    clip_scores=False,
     postprocess=True,
-    queue_name="dalle-mini-tools", 
-    error_queue="dalle-mini-tools_errors", 
+    queue_name="dalle-mini-tools",
+    error_queue="dalle-mini-tools_errors",
     region_name="us-east-1",
     interval=1,
 ):


### PR DESCRIPTION
Background

- Apparently jax is not PEP 503 compatible ([issue](https://github.com/google/jax/issues/5410)). Boo google.
- I was hoping we could use the method [here](https://github.com/python-poetry/poetry/issues/5516#issuecomment-1113751503) but I don't know how to do this with multiple sources/platforms
- [Here's](https://github.com/google/jax/issues/5410#issuecomment-1010557107) a different option that I didn't do
- Instead I just specified the wheel URLs per platform

Updates

- Use newer version of Poetry (1.2 preview)
  - Installed this so we could do [this](https://python-poetry.org/docs/master/repositories/#single-page-link-source) with the jax url, but now I'm not actually using that method... I think it's still ok!
  - See the readme for how to uninstall/reinstall quickly
  - I [deleted](https://python-poetry.org/docs/managing-environments/#deleting-the-environments) the old env first
  - I ran `poetry env list` and then `poetry env remove <envname>`
- Install specific versions of jaxlib using poetry depending on the platform
- Autoformatting/linting cleanup
- I renamed two functions with the same name in b2f8b1ecadd426e3eadb9fc27f07e8a8df5455af
